### PR TITLE
create a harness to test drivers as blackboxes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,9 +5,10 @@ find_package(Threads REQUIRED)
 
 rock_library(iodrivers_base
     SOURCES Driver.cpp Bus.cpp Timeout.cpp IOStream.cpp Exceptions.cpp TCPDriver.cpp
-    IOListener.cpp
+    IOListener.cpp TestStream.cpp
     HEADERS Driver.hpp Bus.hpp Timeout.hpp Status.hpp IOStream.hpp
-    Exceptions.hpp IOListener.hpp TCPDriver.hpp
+    Exceptions.hpp IOListener.hpp TCPDriver.hpp TestStream.hpp
+    Fixture.hpp
     LIBS ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${CMAKE_THREAD_LIBS_INIT}
     DEPS_PKGCONFIG base-types base-lib)
 

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -25,6 +25,7 @@
 #include <boost/lexical_cast.hpp>
 #include <iodrivers_base/IOStream.hpp>
 #include <iodrivers_base/IOListener.hpp>
+#include <iodrivers_base/TestStream.hpp>
 
 #ifdef __gnu_linux__
 #include <linux/serial.h>
@@ -106,6 +107,11 @@ void Driver::setMainStream(IOStream* stream)
     m_stream = stream;
 }
 
+IOStream* Driver::getMainStream() const
+{
+    return m_stream;
+}
+
 void Driver::addListener(IOListener* listener)
 {
     m_listeners.insert(listener);
@@ -124,7 +130,10 @@ void Driver::clear()
 }
 
 Status Driver::getStatus() const
-{ return m_stats; }
+{
+    m_stats.queued_bytes = internal_buffer_size;
+    return m_stats;
+}
 void Driver::resetStatus()
 { m_stats = Status(); }
 
@@ -153,8 +162,8 @@ void Driver::openURI(std::string const& uri)
     //   3 for UDP server
     //   4 for file (either Unix sockets or named FIFOs)
     int mode_idx = -1;
-    char const* modes[5] = { "serial://", "tcp://", "udp://", "udpserver://", "file://" };
-    for (int i = 0; i < 5; ++i)
+    char const* modes[6] = { "serial://", "tcp://", "udp://", "udpserver://", "file://", "test://" };
+    for (int i = 0; i < 6; ++i)
     {
         if (uri.compare(0, strlen(modes[i]), modes[i]) == 0)
         {
@@ -213,6 +222,10 @@ void Driver::openURI(std::string const& uri)
     else if (mode_idx == 4)
     { // file file://path
         return openFile(device);
+    }
+    else if (mode_idx == 5)
+    { // test://
+        setMainStream(new TestStream);
     }
 }
 

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -80,9 +80,10 @@ private:
     /** The current count of bytes left in \c internal_buffer */
     size_t internal_buffer_size;
 
-protected:
+public:
     int const MAX_PACKET_SIZE;
 
+protected:
     /** The underlying object that gives us access to the actual I/O stream
      */
     IOStream* m_stream;
@@ -433,6 +434,10 @@ public:
      * The current I/O stream will be deleted by this operation
      */
     void setMainStream(IOStream* stream);
+
+    /** Gets the main IO stream
+     */
+    IOStream* getMainStream() const;
 
     /** Add a listener stream. The object's ownership is taken by the Driver
      * object.

--- a/src/Fixture.hpp
+++ b/src/Fixture.hpp
@@ -1,0 +1,138 @@
+#ifndef IODRIVERS_BASE_BOOST_FIXTURE_HPP
+#define IODRIVERS_BASE_BOOST_FIXTURE_HPP
+
+#include <iodrivers_base/TestStream.hpp>
+#include <vector>
+
+namespace iodrivers_base
+{
+    /** A fixture class designed to ease testing of iodrivers_base drivers in
+     * boost and GTest
+     *
+     * It creates a given Driver class, which must be opened with the test://
+     * URI. It then provides helper methods to provide access to the underlying
+     * TestStream.
+     *
+     * readPacket/writePacket/pushDataToDevice/readDataFromDevice are then
+     * available within the test.
+     *
+     * In boost-test:
+     *
+     * <code>
+     * BOOST_FIXTURE_TEST(MyTest, Fixture<MyDriver>)
+     * {
+     *   MyDriver.openURI("test://");
+     *   uint8_t buffer[4] = { 0, 1, 2, 3 };
+     *   pushDataToDevice(buffer, buffer + 2);
+     *   auto packet = readPacket();
+     *   // Check that the packet matches the expected extraction
+     * }
+     * </code>
+     *
+     * In GTest:
+     *
+     * <code>
+     * struct DriverTest : ::testing::Test, iodrivers_base::Fixture<MyDriver>
+     * {
+     *    Fixture()
+     *    {
+     *       // Optional: open here
+     *       // driver.openURI("test://")
+     *    }
+     * }
+     * 
+     * TEST_F(DriverTest, it_handles_an_invalid_packet)
+     * {
+     *   MyDriver.openURI("test://");
+     *   uint8_t buffer[4] = { 0, 1, 2, 3 };
+     *   pushDataToDevice(buffer, buffer + 2);
+     *   auto packet = readPacket();
+     *   // Check that the packet matches the expected extraction
+     * }
+     * </code>
+     */
+    template<typename Driver>
+    struct Fixture
+    {
+        std::vector<uint8_t> packetBuffer;
+        Driver driver;
+
+        Fixture()
+        {
+            packetBuffer.resize(driver.MAX_PACKET_SIZE);
+        }
+
+        /** Get the underlying TestStream
+         */
+        TestStream* getStream() const
+        {
+            return dynamic_cast<TestStream*>(driver.getMainStream());
+        }
+
+        /** Read a packet from the driver and return it as an std::vector
+         */
+        std::vector<uint8_t> readPacket()
+        {
+            size_t size = driver.readPacket(packetBuffer.data(), packetBuffer.size());
+            std::vector<uint8_t> packet;
+            packet.insert(packet.end(), packetBuffer.begin(), packetBuffer.begin() + size);
+            return packet;
+        }
+
+        /** Write data to the driver */
+        void writePacket(uint8_t const* buffer, size_t size)
+        {
+            driver.writePacket(buffer, size);
+        }
+
+        /** Push data to the driver "as-if" it was coming from the device
+         */
+        void pushDataToDriver(std::vector<uint8_t> const& data)
+        {
+            return getStream()->pushDataToDriver(data);
+        }
+        
+        /** Helper method to allow passing any kind of uint8_t range
+         *
+         * <code>
+         * uint8_t packet[] = { 0, 1, 2, 3 };
+         * pushDataToDriver(packet, packet + sizeof(packet));
+         * </code>
+         */
+        template<typename Iterator>
+        void pushDataToDriver(Iterator begin, Iterator end)
+        {
+            std::vector<uint8_t> buffer(begin, end);
+            pushDataToDriver(buffer);
+        }
+        
+        /** Read data that the driver sent to the device
+         */
+        std::vector<uint8_t> readDataFromDriver()
+        {
+            return getStream()->readDataFromDriver();
+        }
+
+        /** Return the number of bytes currently queued in the driver's internal
+         * buffer
+         *
+         * This is useful mainly when testing extractPacket
+         *
+         * <code>
+         * TEST_F(DriverTest, KeepsSingleBytes)
+         * {
+         *   uint8_t data = 0x01;
+         *   pushDataToDriver(&data, &data + 1);
+         *   ASSERT_THROW(TimeoutError, readPacket());
+         *   ASSERT_EQUAL(1, getQueuedBytes());
+         * }
+         * </code>
+         */
+        unsigned int getQueuedBytes() const
+        {
+            return driver.getStatus().queued_bytes;
+        }
+    };
+}
+
+#endif

--- a/src/Status.hpp
+++ b/src/Status.hpp
@@ -12,9 +12,10 @@ namespace iodrivers_base {
 	unsigned int tx; //! count of bytes received
 	unsigned int good_rx; //! count of bytes received and accepted
 	unsigned int bad_rx; //! count of bytes received and rejected
+        unsigned int queued_bytes; //! count of bytes currently queued in the driver's internal buffer
 
 	Status()
-	    : tx(0), good_rx(0), bad_rx(0) {}
+	    : tx(0), good_rx(0), bad_rx(0), queued_bytes(0) {}
     };
 }
 

--- a/src/TestStream.cpp
+++ b/src/TestStream.cpp
@@ -1,0 +1,51 @@
+#include <iodrivers_base/TestStream.hpp>
+#include <iodrivers_base/Exceptions.hpp>
+#include <cstring>
+
+using namespace std;
+using namespace iodrivers_base;
+
+/** Push data to the device */
+void TestStream::pushDataToDriver(vector<uint8_t> const& data)
+{
+    to_device.insert(to_device.end(), data.begin(), data.end());
+}
+
+/** Read all data that the device driver has written since the last
+ * call to readDataFromDriver
+ */
+vector<uint8_t> TestStream::readDataFromDriver()
+{
+    vector<uint8_t> temp;
+    temp.swap(from_device);
+    return temp;
+}
+
+void TestStream::waitRead(base::Time const& timeout)
+{
+    if (to_device.empty())
+        throw TimeoutError(TimeoutError::NONE, "no data in to_device");
+}
+void TestStream::waitWrite(base::Time const& timeout)
+{
+}
+
+size_t TestStream::read(uint8_t* buffer, size_t buffer_size)
+{
+    size_t read_size = min(to_device.size(), buffer_size);
+    std::memcpy(buffer, to_device.data(), read_size);
+    to_device.erase(to_device.begin(), to_device.begin() + read_size);
+    return read_size;
+}
+
+size_t TestStream::write(uint8_t const* buffer, size_t buffer_size)
+{
+    from_device.insert(from_device.end(), buffer, buffer + buffer_size);
+    return buffer_size;
+}
+
+void TestStream::clear()
+{
+    to_device.clear();
+}
+

--- a/src/TestStream.hpp
+++ b/src/TestStream.hpp
@@ -1,0 +1,43 @@
+#ifndef IODRIVERS_BASE_HPP
+#define IODRIVERS_BASE_HPP
+
+#include <iodrivers_base/IOStream.hpp>
+#include <vector>
+
+namespace iodrivers_base
+{
+    /** A IOStream meant to be used to test iodrivers_base functionality
+     * from outside
+     *
+     * It maintains two vectors, one the "to device" buffer and one the "from
+     * buffer" device. All communications are synchronous, that is waitRead will
+     * throw right away if no data is available.
+     * waitWrite never fails.
+     */
+
+    class TestStream : public IOStream
+    {
+        std::vector<uint8_t> to_device;
+        std::vector<uint8_t> from_device;
+
+    public:
+        /** Push data to the driver "as-if" it was coming from the device
+         */
+        void pushDataToDriver(std::vector<uint8_t> const& data);
+
+        /** Read data that the driver sent to the device
+         *
+         * This contains only data sent since the last call to
+         * readDataFromDriver
+         */
+        std::vector<uint8_t> readDataFromDriver();
+
+        void waitRead(base::Time const& timeout);
+        void waitWrite(base::Time const& timeout);
+        size_t read(uint8_t* buffer, size_t buffer_size);
+        size_t write(uint8_t const* buffer, size_t buffer_size);
+        void clear();
+    };
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-rock_testsuite(test_suite test.cpp
+rock_testsuite(test_suite suite.cpp
+        test_Driver.cpp test_TestStream.cpp
     DEPS iodrivers_base)
 
 rock_executable(test_tcp_read test_tcp_read.cpp

--- a/test/suite.cpp
+++ b/test/suite.cpp
@@ -1,0 +1,7 @@
+// Do NOT add anything to this file
+// This header from boost takes ages to compile, so we make sure it is compiled
+// only once (here)
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+

--- a/test/test_TestStream.cpp
+++ b/test/test_TestStream.cpp
@@ -1,0 +1,92 @@
+#include <boost/test/unit_test.hpp>
+
+#include <iodrivers_base/Driver.hpp>
+#include <iodrivers_base/Fixture.hpp>
+
+using namespace iodrivers_base;
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(TestStreamSuite)
+
+struct Driver : iodrivers_base::Driver
+{
+public:
+    Driver()
+        : iodrivers_base::Driver(100) {}
+
+    int extractPacket(uint8_t const* buffer, size_t size) const
+    {
+        return size;
+    }
+};
+
+struct Fixture : iodrivers_base::Fixture<Driver>
+{
+    Fixture()
+    {
+        driver.openURI("test://");
+    }
+};
+
+
+BOOST_FIXTURE_TEST_CASE(it_sends_data_to_the_Driver, Fixture)
+{
+    uint8_t data[] = { 0, 1, 2, 3 };
+    pushDataToDriver(data, data + 4);
+    vector<uint8_t> buffer = readPacket();
+    BOOST_REQUIRE(buffer == vector<uint8_t>(data, data + 4));
+}
+
+BOOST_FIXTURE_TEST_CASE(it_accumulates_bytes_not_read_by_the_driver, Fixture)
+{
+    uint8_t data[] = { 0, 1, 2, 3 };
+    pushDataToDriver(data, data + 2);
+    pushDataToDriver(data + 2, data + 4);
+    vector<uint8_t> buffer = readPacket();
+    BOOST_REQUIRE(buffer == vector<uint8_t>(data, data + 4));
+}
+
+BOOST_FIXTURE_TEST_CASE(it_does_not_repeat_data_already_read_by_the_Driver, Fixture)
+{
+    uint8_t data[] = { 0, 1, 2, 3 };
+    pushDataToDriver(data, data + 2);
+    readPacket();
+    pushDataToDriver(data + 2, data + 4);
+    vector<uint8_t> buffer = readPacket();
+    BOOST_REQUIRE(buffer == vector<uint8_t>(data + 2, data + 4));
+}
+
+BOOST_FIXTURE_TEST_CASE(it_times_out_instantly, Fixture)
+{
+    BOOST_REQUIRE_THROW(readPacket(), TimeoutError);
+}
+
+BOOST_FIXTURE_TEST_CASE(it_gives_access_to_the_bytes_sent_by_the_driver, Fixture)
+{
+    uint8_t data[] = { 0, 1, 2, 3 };
+    writePacket(data, 4);
+    std::vector<uint8_t> received = readDataFromDriver();
+    BOOST_REQUIRE(received == vector<uint8_t>(data, data + 4));
+}
+
+BOOST_FIXTURE_TEST_CASE(it_accumulates_unread_bytes, Fixture)
+{
+    uint8_t data[] = { 0, 1, 2, 3 };
+    writePacket(data, 2);
+    writePacket(data + 2, 2);
+    std::vector<uint8_t> received = readDataFromDriver();
+    BOOST_REQUIRE(received == vector<uint8_t>(data, data + 4));
+}
+
+BOOST_FIXTURE_TEST_CASE(it_does_not_repeat_data_already_read_from_the_device, Fixture)
+{
+    uint8_t data[] = { 0, 1, 2, 3 };
+    writePacket(data, 2);
+    readDataFromDriver();
+    writePacket(data + 2, 2);
+    std::vector<uint8_t> received = readDataFromDriver();
+    BOOST_REQUIRE(received == vector<uint8_t>(data + 2, data + 4));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
This uses a stream object (TestStream) that gives direct access
to writing and reading data to/from the driver. A driver can be
initialized with a TestStream as main stream by using the test://
URI, thus allowing to pass through the driver's own open methods.