### PR TITLE
create a generic driver-to-driver forwarding method and command-line tool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ checks on the bytestream as possible.
 This package provides a testing harness that allows you to write integration
 tests drivers based on `iodrivers_base::Driver`. Check the documentation of
 `iodrivers_base/Fixture.hpp` for more information.
+
+## License
+
+This software is licensed under the GNU LGPL version 2 or later
+
+Copyright 2008-2017 DFKI Robotics Innovation Center
+          2014-2017 SENAI-CIMATEC
+          2017-2019 13 Robotics
+          2019      TideWise

--- a/manifest.xml
+++ b/manifest.xml
@@ -5,13 +5,15 @@
         driver that will timeout on read and/or write, and to generically do
         packet extraction in the I/O stream.
     </description>
-    <maintainer>sylvain.joyeux/sylvain.joyeux@dfki.de</maintainer>
-    <copyright>
-        DFKI/robotik@dfki.de
-    </copyright>
+    <maintainer>Sylvain Joyeux/sylvain.joyeux@tidewise.io</maintainer>
+
+    <copyright>2008-2017 DFKI Robotics Innovation Center/robotik@dfki.de</copyright>
+    <copyright>2014-2017 SENAI-CIMATEC</copyright>
+    <copyright>2017-2019 13 Robotics</copyright>
+    <copyright>2019 TideWise</copyright>
+
     <license>LGPL v2 or later</license>
     <url>http://rock-robotics.org/documentation/device_drivers/index.html</url>
-    <tags>stable</tags>
 
     <depend package="base/types" />
     <depend package="base/logging" />

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,12 +5,16 @@ find_package(Threads REQUIRED)
 
 rock_library(iodrivers_base
     SOURCES Driver.cpp Bus.cpp Timeout.cpp IOStream.cpp Exceptions.cpp TCPDriver.cpp
-    IOListener.cpp TestStream.cpp
+    IOListener.cpp TestStream.cpp Forward.cpp
     HEADERS Driver.hpp Bus.hpp Timeout.hpp Status.hpp IOStream.hpp
     Exceptions.hpp IOListener.hpp TCPDriver.hpp TestStream.hpp
-    Fixture.hpp FixtureBoostTest.hpp FixtureGTest.hpp
+    Fixture.hpp FixtureBoostTest.hpp FixtureGTest.hpp Forward.hpp
     LIBS ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${CMAKE_THREAD_LIBS_INIT}
     DEPS_PKGCONFIG base-types base-lib)
+
+rock_executable(iodrivers_base_forwarder
+    SOURCES MainForwarder.cpp
+    DEPS iodrivers_base)
 
 # For backward compatibility only
 install(FILES iodrivers_base.hh iodrivers_bus.hh

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -804,9 +804,10 @@ int Driver::readPacket(uint8_t* buffer, int buffer_size, int packet_timeout, int
         catch(TimeoutError& e)
         {
             throw TimeoutError(timeout_type,
-                "readPacket(): no data after retrying with remaining time "
-                + boost::lexical_cast<string>(remaining_timeout) + "ms of "
-                + boost::lexical_cast<string>(timeout) +"ms timeout");
+                "readPacket(): no data waiting for data. Last wait lasted "
+                + boost::lexical_cast<string>(remaining_timeout) + "ms, "
+                + "out of a total timeout of " +
+                boost::lexical_cast<string>(timeout) + "ms");
         }
     }
 }

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -140,9 +140,9 @@ void Driver::resetStatus()
 void Driver::setExtractLastPacket(bool flag) { m_extract_last = flag; }
 bool Driver::getExtractLastPacket() const { return m_extract_last; }
 
-void Driver::setFileDescriptor(int fd, bool auto_close)
+void Driver::setFileDescriptor(int fd, bool auto_close, bool has_eof)
 {
-    setMainStream(new FDStream(fd, auto_close));
+    setMainStream(new FDStream(fd, auto_close, has_eof));
 }
 
 int Driver::getFileDescriptor() const
@@ -237,7 +237,7 @@ void Driver::openTestMode()
 
 bool Driver::openSerial(std::string const& port, int baud_rate)
 {
-    setFileDescriptor(Driver::openSerialIO(port, baud_rate));
+    setFileDescriptor(Driver::openSerialIO(port, baud_rate), true, false);
     return true;
 }
 
@@ -849,3 +849,9 @@ bool Driver::writePacket(uint8_t const* buffer, int buffer_size, int timeout)
     }
 }
 
+bool Driver::eof() const
+{
+    if (!m_stream)
+        throw std::runtime_error("eof(): invalid stream");
+    return m_stream->eof();
+}

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -644,6 +644,12 @@ int Driver::readRaw(uint8_t* buffer, int out_buffer_size, base::Time const& time
     base::Time deadline = now + timeout;
     while (buffer_fill < out_buffer_size && now <= deadline)
     {
+        try {
+            m_stream->waitRead(deadline - now);
+        }
+        catch(TimeoutError&) {
+            break;
+        }
         int c = m_stream->read(buffer + buffer_fill,
                                out_buffer_size - buffer_fill);
 

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -350,6 +350,21 @@ public:
 
     /** @overload
      *
+     * Calls readRaw using the default timeout as packet timeout
+     */
+    int readRaw(uint8_t* buffer, int bufsize);
+
+    /** Read raw bytes from the underlying I/O
+     *
+     * Reads as many bytes as received during a time of packet_timeout, not
+     * attempting to extract packets.
+     *
+     * This never throws
+     */
+    int readRaw(uint8_t* buffer, int bufsize, base::Time const& packet_timeout);
+
+    /** @overload
+     *
      * Calls readPacket using the default timeout as packet timeout, and no
      * first byte timeout
      */

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -300,7 +300,7 @@ public:
      * The provided file descriptor must be non-blocking for the timeout
      * functionality to work.
      */
-    void setFileDescriptor(int fd, bool auto_close = true);
+    void setFileDescriptor(int fd, bool auto_close = true, bool has_eof = true);
 
     /** Returns the file descriptor associated with this object. If no file
      * descriptor is assigned, returns INVALID_FD
@@ -479,6 +479,10 @@ public:
      * caller
      */
     void removeListener(IOListener* stream);
+
+    /** Whether the current stream is finished (e.g. end-of-file or disconnected)
+     */
+    bool eof() const;
 
     static std::string printable_com(std::string const& buffer);
     static std::string printable_com(uint8_t const* buffer, size_t buffer_size);

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -158,6 +158,14 @@ protected:
 
     void openIPClient(std::string const& hostname, int port, addrinfo const& hints);
 
+    /** Pull bytes out of the internal buffer into the given buffer
+     *
+     * @param skip offset in the internal buffer where the copy starts. These
+     *             bytes are removed from the internal buffer.
+     * @param size number of bytes copied to the output buffer
+    */
+    void pullBytesFromInternal(uint8_t* buffer, int skip, int size);
+
 public:
     /** Creates an Driver class for a packet-based protocol
      *

--- a/src/Forward.cpp
+++ b/src/Forward.cpp
@@ -1,0 +1,77 @@
+#include <iodrivers_base/Forward.hpp>
+#include <iodrivers_base/Driver.hpp>
+#include <thread>
+#include <vector>
+
+using namespace std;
+using namespace iodrivers_base;
+
+struct QuitGuard
+{
+    bool& quitFlag;
+    Driver& driver1;
+    Driver& driver2;
+
+    ~QuitGuard() {
+        quitFlag = true;
+    }
+};
+
+void iodrivers_base::forward(bool raw_mode,
+                Driver& driver1, Driver& driver2,
+                base::Time timeout1,
+                base::Time timeout2,
+                size_t const buffer_size)
+{
+    vector<uint8_t> buffer(buffer_size);
+    int fd1 = driver1.getFileDescriptor();
+    int fd2 = driver2.getFileDescriptor();
+    int select_nfd = std::max(fd1, fd2) + 1;
+
+
+    typedef int (Driver::*ReadMode)(uint8_t*, int, base::Time const&);
+    ReadMode readMode = raw_mode ? static_cast<ReadMode>(&Driver::readRaw) :
+                                   static_cast<ReadMode>(&Driver::readPacket);
+
+    while (!driver1.eof() && !driver2.eof()) {
+        fd_set set;
+        FD_ZERO(&set);
+        FD_SET(fd1, &set);
+        FD_SET(fd2, &set);
+
+        timeval timeout_spec = {
+            static_cast<time_t>(10),
+            suseconds_t(0)
+        };
+
+        int ret = select(select_nfd, &set, NULL, NULL, &timeout_spec);
+        if (ret < 0 && errno != EINTR)
+            throw UnixError("forward(): error in select()");
+        else if (ret == 0)
+            continue;
+
+        if (FD_ISSET(fd1, &set)) {
+            int size = 0;
+            try {
+                size = (driver1.*readMode)(&buffer[0], buffer_size, timeout1);
+            }
+            catch(TimeoutError&) {
+            }
+            if (size != 0) {
+                driver2.writePacket(&buffer[0], size);
+            }
+        }
+
+        if (FD_ISSET(fd2, &set)) {
+            int size = 0;
+            try {
+                size = (driver2.*readMode)(&buffer[0], buffer_size, timeout2);
+            }
+            catch(TimeoutError&) {
+            }
+            if (size != 0) {
+                driver1.writePacket(&buffer[0], size);
+            }
+        }
+    }
+}

--- a/src/Forward.hpp
+++ b/src/Forward.hpp
@@ -8,17 +8,37 @@ namespace iodrivers_base {
 
     /** Forward data between two subclasses of iodrivers_base::Driver
      *
-     * It blocks until one of the drivers is closed
+     * It blocks until one of the connections is closed (the driver
+     * detects an EOF)
+     *
+     * The timeouts are meant to be used to avoid passing data byte-by-byte.
+     * This is important when forwarding from a relatively slow connection (e.g.
+     * serial) to a packet-based connection that has an overhead (e.g. UDP).
+     *
+     * With a non-zero timeout, the driver will read few bytes, push them as a
+     * packet and repeat. This would have a dramatic effect on performance on
+     * the packet-based side. A well-chosen timeout would:
+     *
+     * <li>
+     * <ul> allow the driver to read bytes in bigger chunks. This is dependent
+     *      on the connection type and speed (and, in smaller part, on the
+     *      sending device)
+     * <ul> not have a significant effect on latency for your application. The
+     *      timeout as it is implemented is a maximum latency value between the
+     *      reception of a first byte and the sending of the bytes received.
+     * </li>
      *
      * @param raw_mode whether bytes are read using readRaw (true) or readPacket(false)
      * @param driver1 one of the two drivers
      * @param timeout1 how long we should wait, while reading, before
-     *                 forwarding the data received from driver2. Set to avoid
-     *                 unnecessary fragmentation
+     *                 forwarding the data received from driver2. Set to a
+     *                 nonzero value to gather bytes into bigger chunks when
+     *                 forwarding from a slow connection
      * @param driver2 the other driver
      * @param timeout2 how long we should wait, while reading, before
      *                 forwarding the data received from driver2. Set to avoid
-     *                 unnecessary fragmentation
+     *                 nonzero value to gather bytes into bigger chunks when
+     *                 forwarding from a slow connection
      * @param buffer_size the size of the reading buffer size. In practice,
      *                    it sets the maximum size of a forwarded packet
      */

--- a/src/Forward.hpp
+++ b/src/Forward.hpp
@@ -1,0 +1,31 @@
+#ifndef IODRIVERS_BASE_FORWARD_HPP
+#define IODRIVERS_BASE_FORWARD_HPP
+
+#include <base/Time.hpp>
+
+namespace iodrivers_base {
+    class Driver;
+
+    /** Forward data between two subclasses of iodrivers_base::Driver
+     *
+     * It blocks until one of the drivers is closed
+     *
+     * @param raw_mode whether bytes are read using readRaw (true) or readPacket(false)
+     * @param driver1 one of the two drivers
+     * @param timeout1 how long we should wait, while reading, before
+     *                 forwarding the data received from driver2. Set to avoid
+     *                 unnecessary fragmentation
+     * @param driver2 the other driver
+     * @param timeout2 how long we should wait, while reading, before
+     *                 forwarding the data received from driver2. Set to avoid
+     *                 unnecessary fragmentation
+     * @param buffer_size the size of the reading buffer size. In practice,
+     *                    it sets the maximum size of a forwarded packet
+     */
+    void forward(bool raw_mode, Driver& driver1, Driver& driver2,
+                 base::Time timeout1 = base::Time(),
+                 base::Time timeout2 = base::Time(),
+                 size_t buffer_size = 32768);
+}
+
+#endif

--- a/src/IOStream.hpp
+++ b/src/IOStream.hpp
@@ -77,6 +77,7 @@ namespace iodrivers_base
         sockaddr m_si_other;
         unsigned int m_s_len;
         bool m_si_other_dynamic;
+        bool m_has_other;
     };
 }
 

--- a/src/IOStream.hpp
+++ b/src/IOStream.hpp
@@ -26,6 +26,8 @@ namespace iodrivers_base
         virtual size_t write(uint8_t const* buffer, size_t buffer_size) = 0;
         virtual void clear() = 0;
 
+        virtual bool eof() const;
+
         /** If this IOStream is attached to a file descriptor, return it. Otherwise,
          * returns INVALID_FD;
          *
@@ -40,18 +42,21 @@ namespace iodrivers_base
         bool m_auto_close;
 
     protected:
+        bool m_has_eof;
+        bool m_eof;
         int m_fd;
 
     public:
         static const int INVALID_FD      = -1;
 
-        FDStream(int fd, bool auto_close);
+        FDStream(int fd, bool auto_close, bool has_eof = true);
         virtual ~FDStream();
         virtual void waitRead(base::Time const& timeout);
         virtual void waitWrite(base::Time const& timeout);
         virtual size_t read(uint8_t* buffer, size_t buffer_size);
         virtual size_t write(uint8_t const* buffer, size_t buffer_size);
         virtual void clear();
+        virtual bool eof() const;
 
         /** Sets the NONBLOCK flag on the given file descriptor and returns true if
          * the file descriptor was in blocking mode
@@ -61,7 +66,6 @@ namespace iodrivers_base
         virtual int getFileDescriptor() const;
     };
 
-    
     class UDPServerStream : public FDStream
     {
     public:

--- a/src/MainForwarder.cpp
+++ b/src/MainForwarder.cpp
@@ -1,0 +1,50 @@
+#include <iodrivers_base/Forward.hpp>
+#include <iodrivers_base/Driver.hpp>
+#include <iostream>
+#include <thread>
+
+using namespace std;
+using namespace iodrivers_base;
+
+static void usage(ostream& out) {
+    out << "iodrivers_base_forwarder URI1 TIMEOUT1 URI2 TIMEOUT2\n"
+        << "  forwards data (two-way) between URI1 and URI2, which must both\n"
+        << "  be valid iodrivers_base URIs\n"
+        << "\n"
+        << "  TIMEOUT1 and TIMEOUT2 define how long (in milliseconds) the forwarder should\n"
+        << "  wait on read before forwarding the data, to avoid unnecessary fragmentation\n"
+        << flush;
+}
+
+static const int BUFFER_SIZE = 32768;
+
+class RawIODriver : public iodrivers_base::Driver {
+    int extractPacket(uint8_t const* buffer, size_t buffer_size) const {
+        return 0;
+    }
+public:
+    RawIODriver()
+        : Driver(BUFFER_SIZE) {}
+};
+
+int main(int argc, char** argv) {
+    if (argc != 5) {
+        usage(argc == 1 ? cout : cerr);
+        return argc == 1 ? 0 : 1;
+    }
+
+    string uri1 = argv[1];
+    base::Time timeout1 = base::Time::fromMilliseconds(atoi(argv[2]));
+    string uri2 = argv[3];
+    base::Time timeout2 = base::Time::fromMilliseconds(atoi(argv[4]));
+
+    while(true) {
+        RawIODriver driver1;
+        driver1.openURI(uri1);
+        RawIODriver driver2;
+        driver2.openURI(uri2);
+
+        forward(true, driver1, driver2, timeout1, timeout2, BUFFER_SIZE);
+    }
+    return 0;
+}

--- a/src/TestStream.cpp
+++ b/src/TestStream.cpp
@@ -7,6 +7,12 @@
 using namespace std;
 using namespace iodrivers_base;
 
+TestStream::TestStream()
+    : m_mock_mode(false)
+    , m_eof(false)
+{
+}
+
 /** Push data to the driver */
 void TestStream::pushDataToDriver(vector<uint8_t> const& data)
 {
@@ -34,7 +40,7 @@ void TestStream::waitWrite(base::Time const& timeout)
 
 void TestStream::EXPECT_REPLY(std::vector<uint8_t> const& expectation, std::vector<uint8_t> const& reply)
 {
-    if(!mock_mode)
+    if(!m_mock_mode)
         throw MockContextException();
     expectations.push_back(expectation);
     replies.push_back(reply);
@@ -51,7 +57,7 @@ size_t TestStream::read(uint8_t* buffer, size_t buffer_size)
 
 size_t TestStream::write(uint8_t const* buffer, size_t buffer_size)
 {
-    if(mock_mode)
+    if(m_mock_mode)
     {
         from_driver.insert(from_driver.end(), buffer, buffer + buffer_size);
         if(expectations.empty())
@@ -114,6 +120,16 @@ bool TestStream::expectationsAreEmpty()
 
 void TestStream::setMockMode(bool mode)
 {
-    mock_mode = mode;
+    m_mock_mode = mode;
     from_driver.clear();
+}
+
+bool TestStream::eof() const
+{
+    return m_eof;
+}
+
+void TestStream::setEOF(bool flag)
+{
+    m_eof = flag;
 }

--- a/src/TestStream.hpp
+++ b/src/TestStream.hpp
@@ -22,12 +22,12 @@ namespace iodrivers_base
         std::vector<uint8_t> from_driver;
         std::list<std::vector<uint8_t> > expectations;
         std::list<std::vector<uint8_t> > replies;
-        bool mock_mode;       
+        bool m_mock_mode;
+        bool m_eof;
 
     public:
-        TestStream(): mock_mode(false)
-        {}
-        
+        TestStream();
+
         /** Push data to the driver "as-if" it was coming from the device
          */
         void pushDataToDriver(std::vector<uint8_t> const& data);
@@ -54,6 +54,8 @@ namespace iodrivers_base
         bool expectationsAreEmpty();
         void setMockMode(bool mode);
         void clearExpectations();
+        void setEOF(bool eof);
+        virtual bool eof() const;
     };
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 rock_testsuite(test_suite suite.cpp
-    test_Driver.cpp test_TestStream.cpp
+    test_Driver.cpp test_TestStream.cpp test_Forward.cpp
     DEPS iodrivers_base)
 
 rock_gtest(test_TestStreamGTest
    test_TestStreamGTest.cpp
    HEADERS
    DEPS iodrivers_base)
-    
+
 rock_executable(test_tcp_read test_tcp_read.cpp
     DEPS iodrivers_base
     NOINSTALL)

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -45,7 +45,9 @@ int setupDriver(Driver& driver)
 
 void writeToDriver(Driver& driver, int tx, uint8_t const* data, int size)
 {
-    write(tx, data, size);
+    if (write(tx, data, size) != size) {
+        throw std::runtime_error("failed writing the test data");
+    }
 }
 
 BOOST_AUTO_TEST_SUITE(FileGuardSuite)
@@ -370,6 +372,95 @@ BOOST_AUTO_TEST_CASE(test_send_from_bidirectional_udp)
     peer.close();
 
     BOOST_REQUIRE((count == 4) && (memcmp(buffer, msg, count) == 0));
+}
+
+BOOST_AUTO_TEST_CASE(test_readRaw_throws_if_the_driver_is_not_valid)
+{
+    DriverTest test;
+    BOOST_REQUIRE_THROW(test.readRaw(nullptr, 0), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(test_readRaw_reads_the_bytes_available)
+{
+    DriverTest test;
+    int tx = setupDriver(test);
+    FileGuard tx_guard(tx);
+
+    uint8_t msg[16] = { 'g', 'a', 'r', 'b', 0, 'a', 'b', 0, 'b', 'a', 'g', 'e', 0, 'c', 'd', 0 };
+    writeToDriver(test, tx, msg, 16);
+    uint8_t buffer[16];
+    int size = test.readRaw(buffer, 16);
+    BOOST_REQUIRE_EQUAL(16, size);
+    BOOST_REQUIRE_EQUAL(memcmp(buffer, msg, 16), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_readRaw_consumes_the_bytes_it_has_read)
+{
+    DriverTest test;
+    int tx = setupDriver(test);
+    FileGuard tx_guard(tx);
+
+    uint8_t msg[16] = { 'g', 'a', 'r', 'b', 0, 'a', 'b', 0, 'b', 'a', 'g', 'e', 0, 'c', 'd', 0 };
+    writeToDriver(test, tx, msg, 16);
+    uint8_t expectedBuffer[16] = { 1, 2, 3, 4 };
+    uint8_t buffer[16];
+    test.readRaw(buffer, 16);
+
+    memcpy(buffer, expectedBuffer, 16);
+    int size = test.readRaw(buffer, 4);
+    BOOST_REQUIRE_EQUAL(0, size);
+    // The buffer should not be modified
+    BOOST_REQUIRE_EQUAL(memcmp(buffer, expectedBuffer, 4), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_readRaw_read_bytes_from_the_internal_buffer)
+{
+    DriverTest test;
+    int tx = setupDriver(test);
+    FileGuard tx_guard(tx);
+
+    uint8_t msg[16] = { 0, 'g', 'a', 'r' };
+    writeToDriver(test, tx, msg, 3);
+    uint8_t buffer[100];
+    BOOST_REQUIRE_THROW(test.readPacket(buffer, 100), TimeoutError);
+    int size = test.readRaw(buffer, 3);
+    BOOST_REQUIRE_EQUAL(3, size);
+    BOOST_REQUIRE_EQUAL(memcmp(buffer, msg, 3), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_readRaw_consumes_bytes_from_the_internal_buffer_it_has_read)
+{
+    DriverTest test;
+    int tx = setupDriver(test);
+    FileGuard tx_guard(tx);
+
+    uint8_t msg[16] = { 0, 'g', 'a', 'r' };
+    writeToDriver(test, tx, msg, 3);
+
+    uint8_t buffer[100];
+    BOOST_REQUIRE_THROW(test.readPacket(buffer, 100), TimeoutError);
+    test.readRaw(buffer, 3);
+    int size = test.readRaw(buffer, 3);
+    BOOST_REQUIRE_EQUAL(0, size);
+}
+
+BOOST_AUTO_TEST_CASE(test_readRaw_concatenates_bytes_from_io_and_internal_buffer)
+{
+    DriverTest test;
+    int tx = setupDriver(test);
+    FileGuard tx_guard(tx);
+
+    uint8_t msg0[3] = { 0, 'g', 'a' };
+    uint8_t msg1[13] = { 0, 'a', 'b', 'c', 0, 'b', 'a', 'g', 'e', 0, 'c', 'd', 0 };
+    writeToDriver(test, tx, msg0, 3);
+
+    uint8_t buffer[100];
+    BOOST_REQUIRE_THROW(test.readPacket(msg0, 100), TimeoutError);
+    writeToDriver(test, tx, msg1, 13);
+    int size = test.readRaw(buffer, 100);
+    BOOST_REQUIRE_EQUAL(16, size);
+    BOOST_REQUIRE_EQUAL(memcmp(msg0, buffer, 3), 0);
+    BOOST_REQUIRE_EQUAL(memcmp(msg1, buffer + 3, 13), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -144,6 +144,28 @@ BOOST_AUTO_TEST_CASE(test_open_sets_nonblock)
     BOOST_REQUIRE_THROW(test.readPacket(buffer, 100, 10), TimeoutError);
 }
 
+BOOST_AUTO_TEST_CASE(eof_returns_false_on_valid_file_descriptor) {
+    DriverTest test;
+    setupDriver(test);
+    BOOST_REQUIRE(!test.eof());
+}
+
+BOOST_AUTO_TEST_CASE(eof_returns_true_on_a_closed_file_descriptor_after_a_read) {
+    DriverTest test;
+    int tx = setupDriver(test);
+    close(tx);
+    BOOST_REQUIRE(!test.eof());
+
+    uint8_t buffer[100];
+    BOOST_REQUIRE_THROW(test.readPacket(buffer, 100, base::Time()), TimeoutError);
+    BOOST_REQUIRE(test.eof());
+}
+
+BOOST_AUTO_TEST_CASE(eof_throws_if_the_driver_does_not_have_a_valid_stream) {
+    DriverTest test;
+    BOOST_REQUIRE_THROW(test.eof(), std::runtime_error);
+}
+
 void common_rx_first_packet_extraction(Driver& test, int tx)
 {
     uint8_t buffer[100];

--- a/test/test_Forward.cpp
+++ b/test/test_Forward.cpp
@@ -1,0 +1,200 @@
+#include <boost/test/unit_test.hpp>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <thread>
+
+#include <iodrivers_base/Driver.hpp>
+#include <iodrivers_base/Forward.hpp>
+#include <iodrivers_base/IOStream.hpp>
+
+using namespace std;
+using namespace iodrivers_base;
+
+/** Flow is
+ *
+ * RX/TX is defined w.r.t the forwarder. Flow of data is
+ *
+ * rxSockets[0] -> rxSockets[1] -> rxDriver -> txDriver -> txSockets[0] -> txSockets[1]
+ */
+template <typename Driver>
+struct ForwardFixture {
+    int rxSockets[2];
+    Driver rxDriver;
+    Driver txDriver;
+    int txSockets[2];
+
+    ForwardFixture() {
+        socketpair(AF_UNIX, SOCK_STREAM, 0, rxSockets);
+        socketpair(AF_UNIX, SOCK_STREAM, 0, txSockets);
+        rxDriver.setFileDescriptor(rxSockets[1]);
+        txDriver.setFileDescriptor(txSockets[0]);
+    }
+
+    ~ForwardFixture() {
+        close(rxSockets[0]);
+        close(txSockets[1]);
+    }
+
+    void write(uint8_t const* data, int size) {
+        if (::write(rxSockets[0], data, size) != size) {
+            throw std::runtime_error("failed writing the test data");
+        }
+    }
+
+    int read(uint8_t* data, int size) {
+        return ::read(txSockets[1], data, size);
+    }
+};
+
+class RawForwardDriver : public Driver
+{
+public:
+    RawForwardDriver() : Driver(100) {}
+    int extractPacket(uint8_t const* buffer, size_t buffer_size) const
+    {
+        return 0;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(ForwardSuite_RawMode, ForwardFixture<RawForwardDriver>)
+
+BOOST_AUTO_TEST_CASE(it_quits_if_the_left_connection_closes)
+{
+    thread t([this] { forward(true, rxDriver, txDriver); });
+
+    close(rxSockets[0]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_CASE(it_quits_if_the_right_connection_closes)
+{
+    thread t([this] { forward(true, rxDriver, txDriver); });
+
+    close(txSockets[1]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_CASE(it_forwards_data_from_left_to_right)
+{
+    thread t([this] { forward(true, rxDriver, txDriver); });
+
+    uint8_t buffer[10] = { 1, 2, 3, 4, 5, 6 };
+    write(buffer, 10);
+    read(buffer, 10);
+    close(rxSockets[0]);
+    close(txSockets[1]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_CASE(it_forwards_data_from_right_to_left)
+{
+    thread t([this] { forward(true, txDriver, rxDriver); });
+
+    uint8_t buffer[10] = { 1, 2, 3, 4, 5, 6 };
+    write(buffer, 10);
+    read(buffer, 10);
+    close(rxSockets[0]);
+    close(txSockets[1]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+class PacketForwardDriver : public Driver
+{
+public:
+    PacketForwardDriver() : Driver(100) {}
+    int extractPacket(uint8_t const* buffer, size_t buffer_size) const
+    {
+        for (size_t i = 0; i < buffer_size; ++i) {
+            if (buffer[i] == 0) {
+                return i + 1;
+            }
+        }
+        return 0;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(ForwardSuite_PacketMode, ForwardFixture<PacketForwardDriver>)
+
+BOOST_AUTO_TEST_CASE(it_quits_if_the_left_connection_closes)
+{
+    thread t([this] { forward(false, rxDriver, txDriver); });
+
+    close(rxSockets[0]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_CASE(it_quits_if_the_right_connection_closes)
+{
+    thread t([this] { forward(false, rxDriver, txDriver); });
+
+    close(txSockets[1]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_CASE(it_forwards_whole_packets_from_left_to_right)
+{
+    thread t([this] { forward(false, rxDriver, txDriver); });
+
+    uint8_t buffer[10] = { 1, 2, 3, 0 };
+    write(buffer, 4);
+    uint8_t readBuffer[10];
+    BOOST_REQUIRE_EQUAL(4, read(readBuffer, 4));
+    BOOST_REQUIRE_EQUAL(1, readBuffer[0]);
+    BOOST_REQUIRE_EQUAL(2, readBuffer[1]);
+    BOOST_REQUIRE_EQUAL(3, readBuffer[2]);
+    BOOST_REQUIRE_EQUAL(0, readBuffer[3]);
+
+    close(rxSockets[0]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_CASE(it_does_not_forward_partial_packets_from_left_to_right)
+{
+    thread t([this] { forward(false, rxDriver, txDriver); });
+
+    uint8_t buffer[10] = { 1 };
+    write(buffer, 1);
+
+    FDStream endpoint(txSockets[1], false);
+    BOOST_REQUIRE_EQUAL(0, endpoint.read(buffer, 1));
+
+    close(rxSockets[0]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_CASE(it_forwards_whole_packets_from_right_to_left)
+{
+    thread t([this] { forward(false, txDriver, rxDriver); });
+
+    uint8_t buffer[10] = { 1, 2, 3, 0 };
+    write(buffer, 4);
+    BOOST_REQUIRE_EQUAL(4, read(buffer, 4));
+    BOOST_REQUIRE_EQUAL(1, buffer[0]);
+    BOOST_REQUIRE_EQUAL(2, buffer[1]);
+    BOOST_REQUIRE_EQUAL(3, buffer[2]);
+    BOOST_REQUIRE_EQUAL(0, buffer[3]);
+
+    close(rxSockets[0]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_CASE(it_does_not_forward_partial_packets_from_right_to_left)
+{
+    thread t([this] { forward(false, txDriver, rxDriver); });
+
+    uint8_t buffer[10] = { 1 };
+    write(buffer, 1);
+
+    FDStream endpoint(txSockets[1], false);
+    BOOST_REQUIRE_EQUAL(0, endpoint.read(buffer, 1));
+
+    close(rxSockets[0]);
+    t.join();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The main goal of this PR is to implement iodrivers_base::forward, which allows to pass data (bidirectionally) between two drivers.

With the addition of the `readRaw` method, it allows to have a byte-based forwarding between any stream that `iodrivers_base` supports, such as e.g. serial lines and network. Finally, in order for the forward method to handle closed connections (or disappearing I/O) gracefully, I've implemented a eof() method to check for EOF conditions.

One notable change is that the udpserver:// method will now ignore writes until it has a client. This is in my mind a reasonable behavior for a "server".