### PR TITLE
implement inter-byte timeout in readRaw

### DIFF
--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -362,14 +362,30 @@ public:
      */
     int readRaw(uint8_t* buffer, int bufsize);
 
+    /** @overload
+     *
+     * Use the same timeout for first byte and packet
+     */
+    int readRaw(uint8_t* buffer, int bufsize, base::Time const& timeout);
+
     /** Read raw bytes from the underlying I/O
      *
-     * Reads as many bytes as received during a time of packet_timeout, not
-     * attempting to extract packets.
+     * Reads as many bytes as possible within the time boundaries specified
+     * by its timeout parameters, not attempting to extract packets
+     *
+     * @arg packet_timeout the overall timeout. The method will return at most
+     *   after that much time has elapsed
+     * @arg first_byte_timeout return if no bytes are received within that
+     *   much time
+     * @arg inter_byte_timeout return if no new bytes have been received after
+     *   that much time has elapsed since the last received byte
      *
      * This never throws
      */
-    int readRaw(uint8_t* buffer, int bufsize, base::Time const& packet_timeout);
+    int readRaw(uint8_t* buffer, int bufsize,
+                base::Time const& packet_timeout,
+                base::Time const& first_byte_timeout,
+                base::Time const& inter_byte_timeout = base::Time());
 
     /** @overload
      *

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -409,7 +409,9 @@ public:
      * @throws TimeoutError on timeout or no data, and UnixError on reading problems
      * @returns the size of the packet
      */
-    int readPacket(uint8_t* buffer, int bufsize, base::Time const& packet_timeout, base::Time const& first_byte_timeout);
+    int readPacket(uint8_t* buffer, int bufsize,
+                   base::Time const& packet_timeout,
+                   base::Time const& first_byte_timeout);
 
     /** @overload
      *


### PR DESCRIPTION
This essentially allows to reduce how long it takes to reach timeout when a first byte has already been received. It also allows to handle protocols such as Modbus which are time-based.