### PR TITLE
add iodrivers_base_cat to display a data stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ separately tested).
 Check the documentation of `iodrivers_base/Fixture.hpp` for more information
 on how to use the harness.
 
+## Command-line tools
+
+This package provides two command-line utilities:
+
+- `iodrivers_base_forward` forwards one data stream to another. Both streams are
+  defined by iodrivers_base's URIs
+- `iodrivers_base_cat` outputs the data from a stream to stdout, in hex and
+  ascii formats
+
+For anything more complicated, we recommend usage of
+[socat](https://linux.die.net/man/1/socat)
+
 ## Gotchas
 
 * do not overload `openURI`. This will make testing harder (you have to

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,10 @@ rock_library(iodrivers_base
     LIBS ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${CMAKE_THREAD_LIBS_INIT}
     DEPS_PKGCONFIG base-types base-lib)
 
+rock_executable(iodrivers_base_cat
+    SOURCES MainCat.cpp
+    DEPS iodrivers_base)
+
 rock_executable(iodrivers_base_forwarder
     SOURCES MainForwarder.cpp
     DEPS iodrivers_base)

--- a/src/MainCat.cpp
+++ b/src/MainCat.cpp
@@ -1,0 +1,87 @@
+#include <iodrivers_base/Driver.hpp>
+#include <iostream>
+#include <iomanip>
+#include <thread>
+
+using namespace std;
+using namespace iodrivers_base;
+
+static void usage(ostream& out) {
+    out << "iodrivers_base_cat URI [TIMEOUT]\n"
+        << "  displays data coming from a iodrivers_base-compatible URI"
+        << "\n"
+        << "  TIMEOUT defines how long (in milliseconds) the program should\n"
+        << "  wait on read before displaying it. Defaults to 100ms\n"
+        << flush;
+}
+
+static const int BUFFER_SIZE = 32768;
+static const int COLUMN_SIZE = 8;
+static const int LINE_SIZE = COLUMN_SIZE * 3;
+
+class RawIODriver : public iodrivers_base::Driver {
+    int extractPacket(uint8_t const* buffer, size_t buffer_size) const {
+        return 0;
+    }
+public:
+    RawIODriver()
+        : Driver(BUFFER_SIZE) {}
+};
+
+void displayAscii(char* line) {
+    for (int i = 0; i < LINE_SIZE; ++i) {
+        if (i && i % COLUMN_SIZE == 0) {
+            cout << " ";
+        }
+
+        cout << line[i];
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc != 2 && argc != 3) {
+        usage(argc == 1 ? cout : cerr);
+        return argc == 1 ? 0 : 1;
+    }
+
+    string uri = argv[1];
+    int timeout_ms = 100;
+    if (argc == 3) {
+        timeout_ms = atoi(argv[2]);
+    }
+
+    base::Time timeout = base::Time::fromMilliseconds(timeout_ms);
+
+    uint8_t buffer[BUFFER_SIZE];
+    int pos = 0;
+    char line[LINE_SIZE];
+
+    while (true) {
+        RawIODriver driver;
+        driver.openURI(uri);
+
+        while (true) {
+            int count = driver.readRaw(buffer, BUFFER_SIZE, timeout);
+            for (int i = 0; i < count; ++i) {
+                if (pos) {
+                    cout << " ";
+                    if (pos % LINE_SIZE == 0) {
+                        cout << "  ";
+                        displayAscii(line);
+                        cout << "\n";
+                        pos = 0;
+                    }
+                    else if (pos % COLUMN_SIZE == 0) {
+                        cout << "  ";
+                    }
+                }
+
+                line[pos] = isprint(buffer[i]) ? buffer[i] : '.';
+                cout << hex << setw(2) << setfill('0') << static_cast<int>(buffer[i]);
+                ++pos;
+            }
+        }
+    }
+    return 0;
+}
+


### PR DESCRIPTION
The display is in hex/ascii format, like e.g. hexdump

~~~
38 3a 3e 31 30 30 34 4c   72 51 71 55 6a 73 46 51   3a 6d 36 6b 50 30 44 4d   8:>1004L rQqUjsFQ :m6kP0DM
3a 2c 30 2a 35 43 0d 0a   21 41 49 56 44 4d 2c 31   2c 31 2c 2c 41 2c 42 3a   :,0*5C.. !AIVDM,1 ,1,,A,B:
55 38 43 53 50 30 30 47   3e 53 6e 3c 4c 66 56 4a   3e 3e 43 77 71 55 57 50   U8CSP00G >Sn<LfVJ >>CwqUWP
~~~