### PR TITLE
use CMake's builtin support for C++ standard selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
 find_package(Rock)
-rock_activate_cxx11()
+set(CMAKE_CXX_STANDARD 11)
 rock_init(iodrivers_base 0.1)
 rock_standard_layout()


### PR DESCRIPTION
CMake has builtin support for C++ standard selection ever since v3.1. I really think we should use this instead of the Rock macro (which, by the way, uses CMake's builtin)

See https://www.rock-robotics.org/rock-and-syskit/libraries/cpp_libraries.html#cxx_standard