### PR TITLE
udp: improve handling of network errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,27 @@ warnings and ensure your code will continue working as-is when the defaults chan
   `local_port` option) are configured with `connected=0` and `ignore_connrefused=1`
   by default.
 
+**Host and Network Unreachable errors** If configured to do so, UDP streams
+will either report or ignore host and/or network unreachable errors, as
+reported by the underlying socket implementation This is controlled
+respectively by the `ignore_hostunreach` and `ignore_netunreach` parameters
+which have to be set to 0 or 1. The default is to not ignore the error.
+
+Note that the reliability of this error reporting is complex. They may be reported
+locally if the localhost routing tables do not provide a link to the target,
+but may also depend on the reception of a ICMP message, sent by routers on the path
+to the remote host. In this latter case, the error might not appear at all if
+this message is not sent by the remote peer, or if the ICMP message is
+blocked. Moreover, the error reporting in this case is asynchronous and will
+be reported on follow-up `writePacket` or `readPacket` after the ICMP message
+is received, that is after the actuall `writePacket` call that generated the
+error in the first place.
+
+The recommendation is to keep the default in situations where the path to the
+remote host should always be available - i.e. wired scenarios. Disable both
+of them when using wireless links, as some wireless routers report these
+errors when the link is down.
+
 ### udpserver://
 
 Passively listens to UDP packets on a given port. Writing to the driver will send

--- a/manifest.xml
+++ b/manifest.xml
@@ -14,11 +14,10 @@
 
     <license>LGPL v2 or later</license>
     <url>http://rock-robotics.org/documentation/device_drivers/index.html</url>
-    <tags>stable</tags>
 
     <depend package="base/types" />
     <depend package="base/logging" />
     <depend package="boost" />
-    <test_depend package="libgtest-dev" /> 
+    <test_depend package="libgtest-dev" />
     <test_depend package="google-mock" />
 </package>

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -288,7 +288,10 @@ public:
     */
     void openUDPBidirectional(
         std::string const& hostname, int remote_port, int local_port,
-        bool ignore_connrefused, bool connected
+        bool ignore_connrefused,
+        bool connected,
+        bool ignore_hostunreach = true,
+        bool ignore_netunreach = true
     );
 
     /** Opens a serial port and sets it up to a sane configuration.  Use

--- a/src/IOStream.cpp
+++ b/src/IOStream.cpp
@@ -9,7 +9,9 @@
 
 #include <errno.h>
 #include <iostream>
+#include <tuple>
 
+using namespace std;
 using namespace iodrivers_base;
 
 IOStream::~IOStream() {}
@@ -33,6 +35,10 @@ FDStream::~FDStream()
     if (m_auto_close)
         ::close(m_fd);
 }
+void FDStream::setAutoClose(bool flag) {
+    m_auto_close = flag;
+}
+
 void FDStream::waitRead(base::Time const& timeout)
 {
     fd_set set;
@@ -111,6 +117,8 @@ UDPServerStream::UDPServerStream(int fd, bool auto_close)
     , m_si_other_dynamic(true)
     , m_has_other(false)
     , m_ignore_econnrefused(true)
+    , m_ignore_ehostunreach(true)
+    , m_ignore_enetunreach(true)
 {
 }
 
@@ -121,11 +129,27 @@ UDPServerStream::UDPServerStream(int fd, bool auto_close, struct sockaddr *si_ot
     , m_si_other_dynamic(false)
     , m_has_other(true)
     , m_ignore_econnrefused(true)
+    , m_ignore_ehostunreach(true)
+    , m_ignore_enetunreach(true)
 {
+}
+
+void UDPServerStream::setIgnoreEnetUnreach(bool enable) {
+    m_ignore_enetunreach = enable;
+}
+
+void UDPServerStream::setIgnoreEhostUnreach(bool enable) {
+    m_ignore_ehostunreach = enable;
 }
 
 void UDPServerStream::setIgnoreEconnRefused(bool enable) {
     m_ignore_econnrefused = enable;
+}
+
+pair<ssize_t, int> UDPServerStream::recvfrom(uint8_t* buffer, size_t buffer_size,
+                                                  sockaddr* s_other, socklen_t* s_len) {
+    ssize_t ret = ::recvfrom(m_fd, buffer, buffer_size, 0, s_other, s_len);
+    return make_pair(ret, errno);
 }
 
 size_t UDPServerStream::read(uint8_t* buffer, size_t buffer_size)
@@ -134,10 +158,11 @@ size_t UDPServerStream::read(uint8_t* buffer, size_t buffer_size)
     unsigned int s_len = sizeof(si_other);
 
     ssize_t ret;
+    int err;
     if (m_si_other_dynamic)
-        ret = recvfrom(m_fd, buffer, buffer_size, 0, &si_other, &s_len);
+        tie(ret, err) = recvfrom(buffer, buffer_size, &si_other, &s_len);
     else
-        ret = recvfrom(m_fd, buffer, buffer_size, 0, NULL, NULL);
+        tie(ret, err) = recvfrom(buffer, buffer_size, NULL, NULL);
 
     if (ret >= 0){
         m_has_other = true;
@@ -153,14 +178,25 @@ size_t UDPServerStream::read(uint8_t* buffer, size_t buffer_size)
     }
     else
     {
-        if (errno == EAGAIN) {
+        if (err == EAGAIN) {
             return 0;
         }
-        else if (m_ignore_econnrefused && errno == ECONNREFUSED) {
+        else if (m_ignore_econnrefused && err == ECONNREFUSED) {
             return 0;
         }
-        throw UnixError("readPacket(): error reading the file descriptor");
+        else if (m_ignore_ehostunreach && err == EHOSTUNREACH) {
+            return 0;
+        }
+        else if (m_ignore_enetunreach && err == ENETUNREACH) {
+            return 0;
+        }
+        throw UnixError("readPacket(): error reading the file descriptor", err);
     }
+}
+
+pair<ssize_t, int> UDPServerStream::sendto(uint8_t const* buffer, size_t buffer_size) {
+    ssize_t ret = ::sendto(m_fd, buffer, buffer_size, 0, &m_si_other, m_s_len);
+    return make_pair(ret, errno);
 }
 
 size_t UDPServerStream::write(uint8_t const* buffer, size_t buffer_size)
@@ -168,16 +204,24 @@ size_t UDPServerStream::write(uint8_t const* buffer, size_t buffer_size)
     if (! m_has_other)
         return buffer_size;
 
-    ssize_t ret = sendto(m_fd, buffer, buffer_size, 0, &m_si_other, m_s_len);
+    ssize_t ret;
+    int err;
+    tie(ret, err) = sendto(buffer, buffer_size);
     if (ret == -1) {
-        if (errno == EAGAIN && errno == ENOBUFS) {
+        if (err == EAGAIN && err == ENOBUFS) {
             return 0;
         }
-        else if (m_ignore_econnrefused && errno == ECONNREFUSED) {
+        else if (m_ignore_econnrefused && err == ECONNREFUSED) {
             return 0;
+        }
+        else if (m_ignore_ehostunreach && err == EHOSTUNREACH) {
+            return buffer_size;
+        }
+        else if (m_ignore_enetunreach && err == ENETUNREACH) {
+            return buffer_size;
         }
 
-        throw UnixError("UDPServerStream: writePacket(): error during write");
+        throw UnixError("UDPServerStream: writePacket(): error during write", err);
     }
     return ret;
 }

--- a/src/IOStream.cpp
+++ b/src/IOStream.cpp
@@ -212,7 +212,7 @@ size_t UDPServerStream::write(uint8_t const* buffer, size_t buffer_size)
             return 0;
         }
         else if (m_ignore_econnrefused && err == ECONNREFUSED) {
-            return 0;
+            return buffer_size;
         }
         else if (m_ignore_ehostunreach && err == EHOSTUNREACH) {
             return buffer_size;

--- a/src/IOStream.hpp
+++ b/src/IOStream.hpp
@@ -64,6 +64,8 @@ namespace iodrivers_base
         bool setNonBlockingFlag(int fd);
 
         virtual int getFileDescriptor() const;
+
+        void setAutoClose(bool flag);
     };
 
     class UDPServerStream : public FDStream
@@ -74,12 +76,26 @@ namespace iodrivers_base
         virtual size_t read(uint8_t* buffer, size_t buffer_size);
         virtual size_t write(uint8_t const* buffer, size_t buffer_size);
         void setIgnoreEconnRefused(bool enable);
+        void setIgnoreEhostUnreach(bool enable);
+        void setIgnoreEnetUnreach(bool enable);
+
     protected:
+        /** Internal implementation of recvfrom to allow for mocking */
+        virtual std::pair<ssize_t, int> recvfrom(
+            uint8_t* buffer, size_t buffer_size, sockaddr* s_other, socklen_t* s_len
+        );
+        /** Internal implementation of recvfrom to allow for mocking */
+        virtual std::pair<ssize_t, int> sendto(
+            uint8_t const* buffer, size_t buffer_size
+        );
+
         sockaddr m_si_other;
         unsigned int m_s_len;
         bool m_si_other_dynamic;
         bool m_has_other;
         bool m_ignore_econnrefused;
+        bool m_ignore_ehostunreach;
+        bool m_ignore_enetunreach;
     };
 }
 

--- a/src/IOStream.hpp
+++ b/src/IOStream.hpp
@@ -79,6 +79,8 @@ namespace iodrivers_base
         void setIgnoreEhostUnreach(bool enable);
         void setIgnoreEnetUnreach(bool enable);
 
+        void waitRead(base::Time const& timeout);
+
     protected:
         /** Internal implementation of recvfrom to allow for mocking */
         virtual std::pair<ssize_t, int> recvfrom(
@@ -96,6 +98,8 @@ namespace iodrivers_base
         bool m_ignore_econnrefused;
         bool m_ignore_ehostunreach;
         bool m_ignore_enetunreach;
+
+        int m_wait_read_error;
     };
 }
 

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -503,6 +503,14 @@ BOOST_FIXTURE_TEST_SUITE(general_udp_behavior, UDPFixture)
         test.writePacket(receiveBuffer, 100);
     }
 
+    BOOST_AUTO_TEST_CASE(it_does_not_timeout_for_CONNREFUSED_if_ignored)
+    {
+        test.openURI("udp://127.0.0.1:1111?ignore_connrefused=1");
+        auto& stream = UDPServerStreamMock::setup(test);
+        stream.setSendtoReturn(-1, ECONNREFUSED);
+        test.writePacket(receiveBuffer, 100);
+    }
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(udp_without_local_port, UDPFixture)


### PR DESCRIPTION
This pull request adds the ability for the UDP connections to ignore EHOSTUNREACH and ENETUNREACH.
In addition, it fixes two behaviours:
- calling writePacket on a ECONNREFUSED would time out. It now discards the bytes instead.
- calling waitRead while there is an error would return, which would lead readPacket to then time out.

The behavior is now to ignore these errors in waitRead, which allows to ignore time outs there (thus clearly
ignoring the "I have not received any data error") instead of having to catch errors on readPacket.