### PR TITLE
Add missing stdexcept header

### DIFF
--- a/src/SerialConfiguration.cpp
+++ b/src/SerialConfiguration.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <stdexcept>
 
 #include <iodrivers_base/SerialConfiguration.hpp>
 #include <iodrivers_base/URI.hpp>

--- a/src/URI.cpp
+++ b/src/URI.cpp
@@ -1,4 +1,5 @@
 #include <iodrivers_base/URI.hpp>
+#include <stdexcept>
 
 using namespace std;
 


### PR DESCRIPTION
Whatever used to accidentally provide std::invalid_argument in earlier gcc does no longer, so include stdexcept as documented in the various online c++ documentation services.